### PR TITLE
WEB-409: Create `bootstrap.sh` setup script and Document Static Site Hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ There are a number of reasons we do/would make use of static sites and Single Pa
   - this repository is vanilla and runs off of master (`bulib.github.io`) at the base/root as the default
   - [firstyear](https://github.com/bulib/firstyear/settings) uses master as well, but at the path prefaced by its repo name `bulib.github.io/firstyear`
   - [bulib-wc](https://bulib.github.io/bulib-wc/) is hosted from its `gh-pages` branch after a storybook-assisted build step
+    (deploy-storybook [`storybook-to-ghpages`](https://github.com/storybookjs/storybook-deployer#storybook-deployer))
 - **production** hosting is set up by IS&T and can be placed at most subpaths of `www.bu.edu/library` (e.g. `www.bu.edu/library/firstyear`)
   - [`firstyear/deploy.sh`](https://github.com/bulib/firstyear/blob/master/deploy.sh) is an example of a simple prod deployment script
   - jira tickets [FYOS-2](https://bulibrary.atlassian.net/browse/FYOS-2) and [FYOS-3](https://bulibrary.atlassian.net/browse/FYOS-3)
@@ -35,12 +36,20 @@ There are a number of reasons we do/would make use of static sites and Single Pa
 
 ## Setting Up Your Development Environment
 
-We've made a **`bootstrap.sh`** script to help setup a new developer to work with our repositories. This script
-  will install the dependencies, clone various repositories, and aid in the configuration/credentialing.
+We've made a **`bootstrap.sh`** script to help setup a new developer to work with our repositories.
+
+It will install the dependencies, clone various repositories, and aid in the configuration/credentialing.
+
+To run the script, open a terminal and run the following commands to:
+
+1. download the most recent version of the script from `bulib/bulib.github.io`.
+2. make the downloaded script executable (give permissions to run as a script)
+3. execute the bash script
 
 ```bash
+$ wget https://raw.githubusercontent.com/bulib/bulib.github.io/master/bootstrap.sh
 $ chmod +x bootstrap.sh
-$ bootstrap.sh
+$ ./bootstrap.sh
 ```
 
 It should be run (ideally) once in the first week of orientation (or when starting development work) to get

--- a/README.md
+++ b/README.md
@@ -8,6 +8,31 @@
 This repository is a bit of a catch-all at the moment related to internal development. It's used mostly as
   a test-bed for rapid-prototyping and free hosting of websites. It also contains some additional
   onboarding documentation, troubleshooting, and a script for setting up the development environment.
+
+## Static Sites
+
+### Advantages
+
+There are a number of reasons we do/would make use of static sites and Single Page Apps (SPAs) at BU Libraries:
+
+- they're very **easy to deploy** and to understand,
+- they're **cheap** (or even free) to host,
+- they're **low-risk**, since little can "go wrong" in terms of dependencies or updates,
+- and they require far **less maintenance** than running servers
+
+### Workflow, Deployment, and Hosting
+
+- we run static sites **locally** via an `npm run start` command via `es-dev-server` (a lightweight host fluent in modern js)
+- for **staging**, we use [GitHub pages](https://pages.github.com/) on `bulib.github.io`.
+  - this is because it's easy, there's a lot of documentation for how this is done, and it's free
+  - this repository is vanilla and runs off of master (`bulib.github.io`) at the base/root as the default
+  - [firstyear](https://github.com/bulib/firstyear/settings) uses master as well, but at the path prefaced by its repo name `bulib.github.io/firstyear`
+  - [bulib-wc](https://bulib.github.io/bulib-wc/) is hosted from its `gh-pages` branch after a storybook-assisted build step
+- **production** hosting is set up by IS&T and can be placed at most subpaths of `www.bu.edu/library` (e.g. `www.bu.edu/library/firstyear`)
+  - [`firstyear/deploy.sh`](https://github.com/bulib/firstyear/blob/master/deploy.sh) is an example of a simple prod deployment script
+  - jira tickets [FYOS-2](https://bulibrary.atlassian.net/browse/FYOS-2) and [FYOS-3](https://bulibrary.atlassian.net/browse/FYOS-3)
+    have some background information on how to coordinate with IS&T to establish the space and authorize the upload
+
 ## Setting Up Your Development Environment
 
 We've made a **`bootstrap.sh`** script to help setup a new developer to work with our repositories. This script

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# welcome
-a new playground for rapid static site development
+# Welcome to the BU Libraries' Web Services Team
+
+- a playground for rapid static site development and user testing
+- doubles as a hub for additional documentation and development support
+
+## About this Repository
+
+This repository is a bit of a catch-all at the moment related to internal development. It's used mostly as
+  a test-bed for rapid-prototyping and free hosting of websites. It also contains some additional
+  onboarding documentation, troubleshooting, and a script for setting up the development environment.
+## Setting Up Your Development Environment
+
+We've made a **`bootstrap.sh`** script to help setup a new developer to work with our repositories. This script
+  will install the dependencies, clone various repositories, and aid in the configuration/credentialing.
+
+```bash
+$ chmod +x bootstrap.sh
+$ bootstrap.sh
+```
+
+It should be run (ideally) once in the first week of orientation (or when starting development work) to get
+  someone set up to run and edit code. Hopefully it "just works".
+
+If you have any issues running the script, comment out the sections that are giving you trouble and
+  **run the commands manually** line-by-line.
+
+If that's really not working, you can pretty much **give up** and try working with each repository individually
+  as you go. No pressure.
+
+## Suggested Software
+
+### Recommended
+
+- [Visual Studio Code](https://code.visualstudio.com/Download): IDE for viewing and editing code
+  - [lit-html](https://marketplace.visualstudio.com/items?itemName=bierner.lit-html): extension
+  syntax highlighting for `lit-html` web components
+  - [mdx](https://marketplace.visualstudio.com/items?itemName=silvenon.mdx):
+  syntax highlighting for `*.stories.mdx` files (storybook documentation)
+  - [python](https://marketplace.visualstudio.com/items?itemName=ms-python.python): python auto-completion,
+  - [markdown all-in-one](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one):
+  keyboard shortcuts and auto-preview for README and other markdown files.
+  jupyter notebooks, debugging/testing/etc.
+- [InVision](https://www.invisionapp.com/): create and update UI diagrams and clickable prototypes (e.g. [bulib-header](https://projects.invisionapp.com/prototype/bulib-header-cju8tit1y00deol01jekpfew6/play/95738b75))
+- [Postman](https://www.postman.com/): an application for managing, testing, documenting/detailing API usage
+
+### Additional
+
+- [GitHub Desktop](https://desktop.github.com/): manage git commits/history more granularly/visually
+- [Lightshot Screenshot](https://apps.apple.com/us/app/lightshot-screenshot/id526298438): quickly capture
+  and annotate pictures of your screen for mockups, messages, and pull requests
+- [Magnet](https://magnet.crowdcafe.com/) window manager: quickly organize a number of windows (paid)
+- [Jira Desktop](https://apps.apple.com/app/jira-cloud-by-atlassian/id1475897096): access jira on the app

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+
 # -- install software and dependencies -- #
 
 # install xcode (development suite for Mac OSX)
@@ -16,12 +17,17 @@ echo "installing python (and pip)..."
 brew install python
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py
 
+echo "installing pip packages..."
+pip install jupyter   # enable jupyter notebooks development (e.g. 'bulib/playground')
+pip install requests  # handy library for calling APIs from python scripts (e.g. 'bulib/metadata-workbench')
+
 # install node/npm
 echo "installing node (and npm)..."
 brew install node
 
-npm install -g es-dev-server  # static site development/running locally
-npm install -g cypress        # running tests across repositories
+echo "installing global npm packages..."
+npm install -g es-dev-server  # static site development/running locally (e.g. 'bulib/firstyear')
+npm install -g cypress        # running tests across repositories (e.g. 'bulib/bulib-wc', 'bulib/primo-explore-devenv-bu')
 
 
 # -- configure accounts -- #

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# -- install software and dependencies -- #
+
+# install xcode (development suite for Mac OSX)
+echo "installing xcode..."
+xcode -select -- install
+
+# install homebrew (package manager) from github 
+echo "installing homebrew (and coreutils)..."
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+brew install coreutils  # helpful UNIX commands 
+
+# python
+echo "installing python (and pip)..."
+brew install python
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py
+
+# install node/npm
+echo "installing node (and npm)..."
+brew install node
+
+npm install -g es-dev-server  # static site development/running locally
+npm install -g cypress        # running tests across repositories
+
+
+# -- configure accounts -- #
+
+# git config credentials
+echo -n "enter your github username: "
+read github_username
+git config --global user.name "$github_username"
+echo -n "enter your github email: "
+read github_email 
+git config --global user.name "$github_email"
+
+# npm login credentials
+echo -n "enter 'npm' credentials for the following prompts: "
+npm login
+
+
+# -- setup the repositories -- #
+
+# initialize projects directory
+mkdir ~/projects || true
+cd ~/projects 
+
+# clone the web components directory and firstyear site
+git clone https://github.com/bulib/bulib.github.io.git
+git clone https://github.com/bulib/bulib-wc.git
+git clone https://github.com/bulib/firstyear.git
+
+# set up the BU Libraries Search (primo) development environment
+git clone https://github.com/bulib/primo-explore-bu.git
+wget https://github.com/ExLibrisGroup/primo-explore-devenv/archive/master.zip
+unzip master.zip
+rm master.zip
+mv primo-explore-devenv-master primo-explore-devenv  # rename the directory to match the repository name
+cd primo-explore-devenv/primo-explore
+rm -rf custom/ tmp/
+git clone https://github.com/bulib/primo-explore-devenv-bu.git ./
+
+# backend stuff, scripts, and asserted one-offs
+cd ~/projects
+git clone https://github.com/bulib/playhouse.git
+git clone https://github.com/bulib/metadata-workbench.git

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "bulib-welcome",
-  "description": "welcome site for the BU libraries and a playground for static site development",
+  "description": "welcome site for BU Libraries Web Services Team and a playground for static site development",
   "devDependencies": {
-    "bulib-wc": "0.1.32",
+    "bulib-wc": "0.1.56",
     "es-dev-server": "^1.48.1"
   },
   "scripts": {


### PR DESCRIPTION
Jira Ticket: [WEB-409](https://bulibrary.atlassian.net/browse/WEB-409)

### Background
- walking through the devenenv-devenv, primo-explore-bu, and bulib-wc repositories with @mwardlib I realized that
  - most of our running documentation is on a per-repository basis, when any future dev would likely be using each of them
  - I'd yet to create a place to contain recommended software, necessary dependencies, and various forgettable steps
- the changes here are to fill gaps in documentation and to welcome new hires into the libraries

### Description of Changes
- create new `bootstrap.sh` script to automate development environment set-up and configuration
- add documentation about static site hosting and creating staging environments for various static-site projects
- provide a list of links for recommended/helpful software